### PR TITLE
Adding new feature: BlazeLayout.wrapRender

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ Now you can render the layout with:
 BlazeLayout.render('layout1', { top: "header", main: "postList" });
 ~~~
 
+Or you can define a helper to call later with a pre-defined layout:
+
+~~~js
+var dashboardRender = Blaze.wrapRender('dashboardLayout');
+// ... later ...
+dashboardRender({content: 'clientList'});
+~~~
+
 Then you will get output like below:
 
 ~~~html

--- a/lib/client/layout.js
+++ b/lib/client/layout.js
@@ -23,6 +23,12 @@ BlazeLayout.render = function render(layout, regions) {
   });
 };
 
+BlazeLayout.wrapRender = function(layout){
+  return function(regions){
+    return BlazeLayout.render(layout, regions);
+  }
+}
+
 BlazeLayout.reset = function reset() {
   var layout = currentLayout;
   if(layout) {


### PR DESCRIPTION
It's really annoying to be calling over and over the same 
~~~js 
BlazeLayout.render("sameLayout", {top: 'header', main: 'clients'}); 
~~~

So this function wraps BlazeLayout.render and returns a function with a pre-defined layout.

~~~js
var dashboardRender = BlazeLayout.wrapRender('dashboardLayout');
// ... later, just call:

dashboardRender({content: 'clients'});
~~~