### PR TITLE
Use the new Blaze._getTemplate API

### DIFF
--- a/lib/client/layout.js
+++ b/lib/client/layout.js
@@ -108,7 +108,9 @@ BlazeLayout._buildRegionGetter = function _buildRegionGetter(key) {
 
 BlazeLayout._getTemplate = function (layout, rootDomNode) {
   if (Blaze._getTemplate) {
-    // if Meteor 1.2
+    // if Meteor 1.2, see https://github.com/meteor/meteor/pull/4036
+    // using Blaze._getTemplate instead of directly accessing Template allows
+    // packages like Blaze Components to hook into the process
     return Blaze._getTemplate(layout, function () {
       var view = Blaze.getView(rootDomNode);
       // find the closest view with a template instance

--- a/lib/client/layout.js
+++ b/lib/client/layout.js
@@ -135,7 +135,7 @@ BlazeLayout._render = function _render(layout, regions) {
       return Spacebars.include(BlazeLayout._getTemplate(layout, rootDomNode));
     });
 
-    Blaze.render(currentLayout, rootDomNode);
+    Blaze.render(currentLayout, rootDomNode, null, Blaze.getView(rootDomNode));
     currentLayoutName = layout;
   } else {
     BlazeLayout._updateRegions(regions);

--- a/lib/client/layout.js
+++ b/lib/client/layout.js
@@ -106,6 +106,24 @@ BlazeLayout._buildRegionGetter = function _buildRegionGetter(key) {
   };
 };
 
+BlazeLayout._getTemplate = function (layout, rootDomNode) {
+  if (Blaze._getTemplate) {
+    // if Meteor 1.2
+    return Blaze._getTemplate(layout, function () {
+      var view = Blaze.getView(rootDomNode);
+      // find the closest view with a template instance
+      while (view && !view._templateInstance) {
+        view = view.originalParentView || view.parentView;
+      }
+      // return found template instance, or null
+      return (view && view._templateInstance) || null;
+    });
+  }
+  else {
+    return Template[layout];
+  }
+};
+
 BlazeLayout._render = function _render(layout, regions) {
   var rootDomNode = BlazeLayout._getRootDomNode();
   if(currentLayoutName != layout) {
@@ -114,7 +132,7 @@ BlazeLayout._render = function _render(layout, regions) {
     currentData = BlazeLayout._regionsToData(regions);
 
     currentLayout = Blaze._TemplateWith(currentData, function() {
-      return Spacebars.include(Template[layout]);
+      return Spacebars.include(BlazeLayout._getTemplate(layout, rootDomNode));
     });
 
     Blaze.render(currentLayout, rootDomNode);


### PR DESCRIPTION
Implemented in https://github.com/meteor/meteor/pull/4036, the new `Blaze._getTemplate` provides a method to get a template, instead of manually accessing `Template`. This makes Blaze Layout support [Blaze Components](https://github.com/peerlibrary/meteor-blaze-components) out of the box.