### PR TITLE
enable passing Template objects to BlazeLayout.render

### DIFF
--- a/lib/client/layout.js
+++ b/lib/client/layout.js
@@ -1,6 +1,6 @@
 var currentLayoutName = null;
 var currentLayout = null;
-var currentRegions = new ReactiveDict();
+var currentRegions = new ReactiveMap();
 var currentData;
 var _isReady = false;
 
@@ -39,7 +39,7 @@ BlazeLayout.reset = function reset() {
 
     currentLayout = null;
     currentLayoutName = null;
-    currentRegions = new ReactiveDict();
+    currentRegions = new ReactiveMap();
   }
 };
 

--- a/lib/client/layout.js
+++ b/lib/client/layout.js
@@ -107,6 +107,10 @@ BlazeLayout._buildRegionGetter = function _buildRegionGetter(key) {
 };
 
 BlazeLayout._getTemplate = function (layout, rootDomNode) {
+  if (layout instanceof Blaze.Template) {
+    return layout;
+  }
+
   if (Blaze._getTemplate) {
     // if Meteor 1.2, see https://github.com/meteor/meteor/pull/4036
     // using Blaze._getTemplate instead of directly accessing Template allows

--- a/package.js
+++ b/package.js
@@ -23,7 +23,7 @@ function configure(api) {
   api.versionsFrom('1.0');
   api.use('blaze');
   api.use('templating');
-  api.use('reactive-dict');
+  api.use('jagi:reactive-map@2.0.0');
   api.use('underscore');
   api.use('jquery');
   api.use('tracker');


### PR DESCRIPTION
Currently, if you pass a template object in (instead of a string) as the layout to BlazeLayout.render, you receive an error because blaze-layout attempts to lookup the template by name.
If you pass in the template object (instead of a string) as data to BlazeLayout.render, the template doesn't render because the ReactiveDict stringifies the object. 
Adding a simple check for layout template objects and switching to ReactiveMap for the data keeps the existing functionality for strings while allowing Templates to be passed in.

This can be used for vanilla Blaze, although its primarily useful for my Blaze Modules package where Blaze templates can be imported:

``` js
import { FlowRouter } from 'meteor/kadira:flow-router';
import { BlazeLayout } from 'meteor/kadira:blaze-layout';
import layout from './client/layout/layout';
import homePage from './client/homePage/homePage';

BlazeLayout.render(layout, { content: homePage });
```

With vanilla Blaze:

``` js
import { FlowRouter } from 'meteor/kadira:flow-router';
import { BlazeLayout } from 'meteor/kadira:blaze-layout';
import { Template } from 'meteor/templating';
import './client/layout/layout.html';
import './client/homePage/homePage.html';

BlazeLayout.render(Template.layout, { content: Template.homePage });
```
