### PR TITLE
Fix problem re-rendering with same region name

### DIFF
--- a/lib/client/layout.js
+++ b/lib/client/layout.js
@@ -66,8 +66,9 @@ BlazeLayout._updateRegions = function _updateRegions(regions) {
   _.each(regions, function(value, key) {
     // if this key does not yet exist then blaze
     // has no idea about this key and it won't get the value of this key
-    // so, we need to force a re-render
-    if(currentData && currentData[key] === undefined) {
+    // so, we need to force a re-render.
+    // needsRerender when new value of region is different from current one
+    if(value === undefined || (currentData && currentData[key]() !== value)) {
       needsRerender = true;
       // and, add the data function for this new key
       currentData[key] = BlazeLayout._buildRegionGetter(key);


### PR DESCRIPTION
When a route is rendered with same template and same regions fields name, we check only that current region is undefined but we dont compare the new region value with current one.

Fix https://github.com/kadirahq/blaze-layout/issues/72 and https://github.com/kadirahq/blaze-layout/issues/65